### PR TITLE
[Discussion] TodoWithNoRequestDelegate

### DIFF
--- a/TodoWithNoRequestDelegate/Program.cs
+++ b/TodoWithNoRequestDelegate/Program.cs
@@ -1,6 +1,8 @@
+using System;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -23,9 +25,20 @@ namespace Todos
 
             var app = builder.Build();
 
-            TodoApi.MapRoutes(app);
+            TodoApi.MapRoutes(app, Activator);
 
             await app.RunAsync();
         }
+
+        private static RequestDelegate Activator<T>(Func<T, RequestDelegate> handler)
+        {
+            return context =>
+            {
+                var api = context.RequestServices.GetRequiredService<T>();
+                return handler(api)(context);
+            };
+        }
     }
+
+    public delegate RequestDelegate ApiActivator<T>(Func<T, RequestDelegate> inp);
 }

--- a/TodoWithNoRequestDelegate/Program.cs
+++ b/TodoWithNoRequestDelegate/Program.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.EntityFrameworkCore;
@@ -12,6 +13,13 @@ namespace Todos
             var builder = WebApplication.CreateBuilder(args);
 
             builder.Services.AddDbContext<TodoDbContext>(options => options.UseInMemoryDatabase("Todos"));
+            builder.Services.AddScoped<TodoApi.Service>();
+            builder.Services.AddScoped<TodoApi>();
+            builder.Services.AddSingleton(new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true,
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            });
 
             var app = builder.Build();
 

--- a/TodoWithNoRequestDelegate/TodoApi.Service.cs
+++ b/TodoWithNoRequestDelegate/TodoApi.Service.cs
@@ -6,40 +6,43 @@ namespace Todos
 {
     public partial class TodoApi
     {
-        private readonly TodoDbContext _db;
-
-        public TodoApi(TodoDbContext db)
+        public class Service
         {
-            _db = db;
-        }
+            private readonly TodoDbContext _db;
 
-        public async Task<List<Todo>> GetAll()
-        {
-            return await _db.Todos.ToListAsync();
-        }
-
-        public async Task<Todo> Get(long id)
-        {
-            return await _db.Todos.FindAsync(id);
-        }
-
-        public async Task Post(Todo todo)
-        {
-            _db.Todos.Add(todo);
-            await _db.SaveChangesAsync();
-        }
-
-        public async Task<bool> Delete(long id)
-        {
-            var todo = await _db.Todos.FindAsync(id);
-            if (todo == null)
+            public Service(TodoDbContext db)
             {
-                return false;
+                _db = db;
             }
 
-            _db.Todos.Remove(todo);
-            await _db.SaveChangesAsync();
-            return true;
+            public async Task<List<Todo>> GetAll()
+            {
+                return await _db.Todos.ToListAsync();
+            }
+
+            public async Task<Todo> Get(long id)
+            {
+                return await _db.Todos.FindAsync(id);
+            }
+
+            public async Task Post(Todo todo)
+            {
+                _db.Todos.Add(todo);
+                await _db.SaveChangesAsync();
+            }
+
+            public async Task<bool> Delete(long id)
+            {
+                var todo = await _db.Todos.FindAsync(id);
+                if (todo == null)
+                {
+                    return false;
+                }
+
+                _db.Todos.Remove(todo);
+                await _db.SaveChangesAsync();
+                return true;
+            }
         }
     }
 }

--- a/TodoWithNoRequestDelegate/TodoApi.cs
+++ b/TodoWithNoRequestDelegate/TodoApi.cs
@@ -69,21 +69,12 @@ namespace Todos
             }
         }
 
-        public static void MapRoutes(IEndpointRouteBuilder endpoints)
+        public static void MapRoutes(IEndpointRouteBuilder endpoints, ApiActivator<TodoApi> activator)
         {
-            endpoints.MapGet("/api/todos", WithServices(api => api.GetAll));
-            endpoints.MapGet("/api/todos/{id}", WithServices(api => api.Get));
-            endpoints.MapPost("/api/todos", WithServices(api => api.Post));
-            endpoints.MapDelete("/api/todos/{id}", WithServices(api => api.Delete));
-        }
-
-        private static RequestDelegate WithServices(Func<TodoApi, RequestDelegate> handler)
-        {
-            return context =>
-            {
-                var api = context.RequestServices.GetRequiredService<TodoApi>();
-                return handler(api)(context);
-            };
+            endpoints.MapGet("/api/todos", activator(api => api.GetAll));
+            endpoints.MapGet("/api/todos/{id}", activator(api => api.Get));
+            endpoints.MapPost("/api/todos", activator(api => api.Post));
+            endpoints.MapDelete("/api/todos/{id}", activator(api => api.Delete));
         }
     }
 }


### PR DESCRIPTION
- Extract the `Service` into its own class to limit `TodoApi`'s responsibilities
    - I created the `Service` class as a nested class if, for some reason, you wanted to show possibilities of partial classes. It could also be renamed `TodoApiService` and moved to `TodoApiService.cs`, making the file discovery easier (VS nest `TodoApi.*.cs` under `TodoApi.cs` and collapse the file tree by default). I like nested classes to keep a "feature/unit" together.
- Use of constructor injection. 
    - Constructor injection should always be the preferred method, then, if impossible go-to method injection, then property injection. 
    - This has many advantages, starting by guarding against `null` in one place instead of *N* (i.e., required dependencies).
- Move object composition to composition root, getting service locator out of the `TodoApi`.
    - I understand that it needs to happen somewhere, and I way prefer at the framework level. Still, if that needs to occur in the application code, the composition root is a better place than spread across files in an application.
    - I think this should improve maintainability (no app stay small for long; I understand that this is a minimalist sample, but thinking real-life here)
    - Which opens the following question: why is the framework not supporting this use-case, out of the box? We should not need to wire up DI manually when using built-in features. Think about how easy it would be to create a Web API if we could define an endpoint that points to an arbitrary method somewhere with DI, all wired up by the framework! BTW I never thought of that before; your experiment lead me to this conclusion (but now I want that!).