### PR TITLE
Add minimum code for local JWT stuff with claims and policies

### DIFF
--- a/TodoWithControllersAuthJWT/AuthController.cs
+++ b/TodoWithControllersAuthJWT/AuthController.cs
@@ -19,7 +19,7 @@ namespace TodoWithControllersAuthJWT
         {
             _authService = authService ?? throw new ArgumentNullException(nameof(authService));;
         }
-        [HttpGet(nameof(GenerateToken))]
+        [HttpGet("token")]
         public IActionResult GenerateToken([FromQuery] string username, [FromQuery] string password)
         {
             bool isValidUser = _authService.IsValid(username, password);

--- a/TodoWithControllersAuthJWT/AuthController.cs
+++ b/TodoWithControllersAuthJWT/AuthController.cs
@@ -13,26 +13,26 @@ namespace TodoWithControllersAuthJWT
     [AllowAnonymous]
     public class AuthController: ControllerBase
     {
-        private readonly IAuthService _userService;
+        private readonly IAuthService _authService;
 
-        public AuthController(IAuthService userService)
+        public AuthController(IAuthService authService)
         {
-            _userService = userService ?? throw new ArgumentNullException(nameof(userService));;
+            _authService = authService ?? throw new ArgumentNullException(nameof(authService));;
         }
         [HttpGet(nameof(GenerateToken))]
         public IActionResult GenerateToken([FromQuery] string username, [FromQuery] string password)
         {
-            bool isValidUser = _userService.IsValid(username, password);
+            bool isValidUser = _authService.IsValid(username, password);
             if (!isValidUser)
             {
                 return BadRequest("invalid user/pass combination");
             }
-            var claims = _userService.GetUserClaims(username).Select(name => new Claim(name, "true"));
+            var claims = _authService.GetUserClaims(username).Select(name => new Claim(name, "true"));
 
-            var key = new SymmetricSecurityKey(_userService.Key);
+            var key = new SymmetricSecurityKey(_authService.Key);
             var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
             var token = new JwtSecurityToken(
-                issuer: _userService.Issuer,
+                issuer: _authService.Issuer,
                 claims: claims,
                 expires: DateTime.Now.AddMinutes(30),
                 signingCredentials: creds

--- a/TodoWithControllersAuthJWT/AuthController.cs
+++ b/TodoWithControllersAuthJWT/AuthController.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.IdentityModel.Tokens;
+
+namespace TodoWithControllersAuthJWT
+{
+    [ApiController]
+    [Route("/api/auth")]
+    [AllowAnonymous]
+    public class AuthController: ControllerBase
+    {
+        private readonly IAuthService _userService;
+
+        public AuthController(IAuthService userService)
+        {
+            _userService = userService ?? throw new ArgumentNullException(nameof(userService));;
+        }
+        [HttpGet(nameof(GenerateToken))]
+        public IActionResult GenerateToken([FromQuery] string username, [FromQuery] string password)
+        {
+            bool isValidUser = _userService.IsValid(username, password);
+            if (!isValidUser)
+            {
+                return BadRequest("invalid user/pass combination");
+            }
+            var claims = _userService.GetUserClaims(username).Select(name => new Claim(name, "true"));
+
+            var key = new SymmetricSecurityKey(_userService.Key);
+            var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+            var token = new JwtSecurityToken(
+                issuer: _userService.Issuer,
+                claims: claims,
+                expires: DateTime.Now.AddMinutes(30),
+                signingCredentials: creds
+                );
+
+            return Ok(new
+            {
+                token = new JwtSecurityTokenHandler().WriteToken(token)
+            });
+        }
+    }
+}

--- a/TodoWithControllersAuthJWT/Program.cs
+++ b/TodoWithControllersAuthJWT/Program.cs
@@ -1,48 +1,50 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.IdentityModel.Tokens;
+using TodoWithControllersAuthJWT;
 
 namespace Todos
 {
     class Program
     {
-        public static string ISSUER = "iamissuer";
-        public static string AUDIENCE = ISSUER;
-        public static byte[] KEY = Enumerable.Range(0, 100).Select(Convert.ToByte).ToArray();
+        public static string Issuer = "iamissuer";
+        public static byte[] Key = new byte[100];
 
-        public static Dictionary<string, string>  validUsers = new Dictionary<string, string>
+        public static Dictionary<string, (string Password, string[] Claims)>  validUsers = new Dictionary<string, (string Password, string[] Claims)>
         {
-            ["user"] = "123456",
+            ["user"] = ("123456", new[] { "can_delete", "can_view" }),
         };
         static async Task Main(string[] args)
         {
+            RandomNumberGenerator.Create().GetBytes(Key);
             var builder = WebApplication.CreateBuilder(args);
 
             builder.Services.AddDbContext<TodoDbContext>(options => options.UseInMemoryDatabase("Todos"));
-            builder.Services.AddAuthorization(x =>
+            builder.Services.AddSingleton<IAuthService, AuthService>(service => new AuthService(Issuer, Key, validUsers));
+            builder.Services.AddAuthorization(options =>
             {
-                x.AddPolicy("admin", policy => policy.RequireClaim("can_delete", true.ToString().ToLowerInvariant()));
-                x.AddPolicy("user", policy => policy.RequireClaim("can_view", true.ToString().ToLowerInvariant()));
+                options.AddPolicy("admin", policy => policy.RequireClaim("can_delete", "true"));
+                options.AddPolicy("user", policy => policy.RequireClaim("can_view", "true"));
             });
             builder.Services
                 .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
-                .AddJwtBearer(x =>
+                .AddJwtBearer(options =>
                 {
-                    x.TokenValidationParameters = new TokenValidationParameters
+                    options.TokenValidationParameters = new TokenValidationParameters
                     {
                         ValidateIssuer = true,
-                        ValidateAudience = true,
+                        ValidateAudience = false,
                         ValidateLifetime = true,
                         ValidateIssuerSigningKey = true,
-                        ValidIssuer = ISSUER,
-                        ValidAudience = AUDIENCE,
-                        IssuerSigningKey = new SymmetricSecurityKey(KEY)
+                        ValidIssuer = Issuer,
+                        IssuerSigningKey = new SymmetricSecurityKey(Key)
                     };
                 });
             builder.Services.AddControllers();

--- a/TodoWithControllersAuthJWT/Program.cs
+++ b/TodoWithControllersAuthJWT/Program.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Todos
+{
+    class Program
+    {
+        public static string ISSUER = "iamissuer";
+        public static string AUDIENCE = ISSUER;
+        public static byte[] KEY = Enumerable.Range(0, 100).Select(Convert.ToByte).ToArray();
+
+        public static Dictionary<string, string>  validUsers = new Dictionary<string, string>
+        {
+            ["user"] = "123456",
+        };
+        static async Task Main(string[] args)
+        {
+            var builder = WebApplication.CreateBuilder(args);
+
+            builder.Services.AddDbContext<TodoDbContext>(options => options.UseInMemoryDatabase("Todos"));
+            builder.Services.AddAuthorization(x =>
+            {
+                x.AddPolicy("admin", policy => policy.RequireClaim("can_delete", true.ToString().ToLowerInvariant()));
+                x.AddPolicy("user", policy => policy.RequireClaim("can_view", true.ToString().ToLowerInvariant()));
+            });
+            builder.Services
+                .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+                .AddJwtBearer(x =>
+                {
+                    x.TokenValidationParameters = new TokenValidationParameters
+                    {
+                        ValidateIssuer = true,
+                        ValidateAudience = true,
+                        ValidateLifetime = true,
+                        ValidateIssuerSigningKey = true,
+                        ValidIssuer = ISSUER,
+                        ValidAudience = AUDIENCE,
+                        IssuerSigningKey = new SymmetricSecurityKey(KEY)
+                    };
+                });
+            builder.Services.AddControllers();
+
+            var app = builder.Build();
+
+            app.UseAuthentication();
+            app.UseAuthorization();
+            app.MapControllers();
+
+            await app.RunAsync();
+        }
+    }
+}

--- a/TodoWithControllersAuthJWT/README.md
+++ b/TodoWithControllersAuthJWT/README.md
@@ -11,8 +11,8 @@ For demo purposes, Claims are requested on GenerateToken endpoint.
 ```
 # pwsh
 $base = "http://localhost:8888"
-$payload = "username=user&password=123456&desiredClaims=delete&desiredClaims=view"
-$auth = Invoke-RestMethod "$base/api/todos/GenerateToken?$payload" -Method Get
+$payload = "username=user&password=123456"
+$auth = Invoke-RestMethod "$base/api/auth/GenerateToken?$payload" -Method Get
 # $auth should contains token property
 $info = Invoke-RestMethod "$base/api/todos/2" -Headers @{"Authorization" = "Bearer $($auth.token)"}
 ```

--- a/TodoWithControllersAuthJWT/README.md
+++ b/TodoWithControllersAuthJWT/README.md
@@ -1,0 +1,18 @@
+﻿Added JWT for local authentication and authorization.
+
+Now, TodoWithControllersAuthJWT project is available only for users within Program.validUsers dictionary.
+
+All methods from /api/todos (except GenerateToken) will require token validation
+More than that, 
+- GET /api/todos/{id} will require "user" policy, that is defined as "can_view" claim
+- DELETE /api/todos/{id} will require "admin" policy, that is defined as "can_delete" claim
+
+For demo purposes, Claims are requested on GenerateToken endpoint.
+```
+# pwsh
+$base = "http://localhost:8888"
+$payload = "username=user&password=123456&desiredClaims=delete&desiredClaims=view"
+$auth = Invoke-RestMethod "$base/api/todos/GenerateToken?$payload" -Method Get
+# $auth should contains token property
+$info = Invoke-RestMethod "$base/api/todos/2" -Headers @{"Authorization" = "Bearer $($auth.token)"}
+```

--- a/TodoWithControllersAuthJWT/Services/AuthService.cs
+++ b/TodoWithControllersAuthJWT/Services/AuthService.cs
@@ -1,22 +1,25 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
 using TodoWithControllersAuthJWT;
 
 namespace Todos
 {
     internal class AuthService : IAuthService
     {
-        private readonly Dictionary<string, (string Password, string[] Claims)> _users;
-
-        public AuthService(string issuer, byte[] key, Dictionary<string, (string Password, string[] Claims)> users)
+        public AuthService()
         {
-            Issuer = issuer;
-            Key = key;
-            _users = users;
+            Key = Enumerable.Range(0, 100).Select(Convert.ToByte).ToArray();
         }
+        private readonly Dictionary<string, (string Password, string[] Claims)> _users = new Dictionary<string, (string Password, string[] Claims)>
+        {
+            ["user"] = ("123456", new[] { "can_delete", "can_view" }),
+        };
 
-        public string Issuer { get; private set; }
+        public string Issuer { get; private set; } = "iamissuer";
 
-        public byte[] Key { get; private set; }
+        public byte[] Key { get; private set; } = new byte[100];
 
         public string[] GetUserClaims(string username)
         {

--- a/TodoWithControllersAuthJWT/Services/AuthService.cs
+++ b/TodoWithControllersAuthJWT/Services/AuthService.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections.Generic;
+using TodoWithControllersAuthJWT;
+
+namespace Todos
+{
+    internal class AuthService : IAuthService
+    {
+        private readonly Dictionary<string, (string Password, string[] Claims)> _users;
+
+        public AuthService(string issuer, byte[] key, Dictionary<string, (string Password, string[] Claims)> users)
+        {
+            Issuer = issuer;
+            Key = key;
+            _users = users;
+        }
+
+        public string Issuer { get; private set; }
+
+        public byte[] Key { get; private set; }
+
+        public string[] GetUserClaims(string username)
+        {
+            return _users[username].Claims;
+        }
+
+        public bool IsValid(string username, string password)
+        {
+            return _users.ContainsKey(username) && _users[username].Password.CompareTo(password) == 0;
+        }
+    }
+}

--- a/TodoWithControllersAuthJWT/Services/AuthService.cs
+++ b/TodoWithControllersAuthJWT/Services/AuthService.cs
@@ -28,7 +28,7 @@ namespace Todos
 
         public bool IsValid(string username, string password)
         {
-            return _users.ContainsKey(username) && _users[username].Password.CompareTo(password) == 0;
+            return _users.TryGetValue(username, out var data) && string.Equals(data.Password, password);
         }
     }
 }

--- a/TodoWithControllersAuthJWT/Services/IAuthService.cs
+++ b/TodoWithControllersAuthJWT/Services/IAuthService.cs
@@ -1,0 +1,10 @@
+﻿namespace TodoWithControllersAuthJWT
+{
+    public interface IAuthService
+    {
+        bool IsValid(string username, string password);
+        string[] GetUserClaims(string username);
+        string Issuer { get; }
+        byte[] Key { get; }
+    }
+}

--- a/TodoWithControllersAuthJWT/Todo.cs
+++ b/TodoWithControllersAuthJWT/Todo.cs
@@ -1,0 +1,9 @@
+﻿namespace Todos
+{
+    public class Todo
+    {
+        public long Id { get; set; }
+        public string Name { get; set; }
+        public bool IsComplete { get; set; }
+    }
+}

--- a/TodoWithControllersAuthJWT/TodoController.cs
+++ b/TodoWithControllersAuthJWT/TodoController.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Todos
+{
+    [ApiController]
+    [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
+    [Route("/api/todos")]
+    public class TodoController : ControllerBase
+    {
+        private readonly TodoDbContext _db;
+        public TodoController(TodoDbContext db)
+        {
+            _db = db ?? throw new ArgumentNullException(nameof(db));
+        }
+        [AllowAnonymous]
+        [HttpGet(nameof(GenerateToken))]
+        public IActionResult GenerateToken([FromQuery] string username, [FromQuery] string password, [FromQuery] string[] desiredClaims)
+        {
+            bool isValidUser = 
+                Program.validUsers.ContainsKey(username) 
+                && Program.validUsers[username].CompareTo(password) == 0;
+            if (!isValidUser)
+            {
+                return BadRequest("invalid user/pass combination");
+            }
+            var claims = desiredClaims.Select(name => new Claim($"can_{name}", true.ToString().ToLowerInvariant()));
+
+            var key = new SymmetricSecurityKey(Program.KEY);
+            var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+            var token = new JwtSecurityToken(
+                issuer: Program.ISSUER,
+                audience: Program.AUDIENCE,
+                claims: claims,
+                expires: DateTime.Now.AddMinutes(30),
+                signingCredentials: creds
+                );
+
+            return Ok(new
+            {
+                token = new JwtSecurityTokenHandler().WriteToken(token)
+            });
+        }
+        [HttpGet]
+        public async Task<ActionResult<List<Todo>>> GetAll()
+        {
+            var todos = await _db.Todos.ToListAsync();
+
+            return todos;
+        }
+
+        [HttpGet("{id}")]
+        [Authorize("user")]
+        public async Task<ActionResult<Todo>> Get(long id)
+        {
+            var todo = await _db.Todos.FindAsync(id);
+            if (todo == null)
+            {
+                return NotFound();
+            }
+
+            return todo;
+        }
+
+        [HttpPost]
+        public async Task Post(Todo todo)
+        {
+            _db.Todos.Add(todo);
+            await _db.SaveChangesAsync();
+        }
+        [HttpDelete("{id}")]
+        [Authorize("admin")]
+        public async Task<IActionResult> Delete(long id)
+        {
+            var todo = await _db.Todos.FindAsync(id);
+            if (todo == null)
+            {
+                return NotFound();
+            }
+
+            _db.Todos.Remove(todo);
+            await _db.SaveChangesAsync();
+            return Ok();
+        }
+    }
+}

--- a/TodoWithControllersAuthJWT/TodoController.cs
+++ b/TodoWithControllersAuthJWT/TodoController.cs
@@ -1,15 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IdentityModel.Tokens.Jwt;
-using System.Linq;
-using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.IdentityModel.Tokens;
 
 namespace Todos
 {
@@ -22,34 +18,6 @@ namespace Todos
         public TodoController(TodoDbContext db)
         {
             _db = db ?? throw new ArgumentNullException(nameof(db));
-        }
-        [AllowAnonymous]
-        [HttpGet(nameof(GenerateToken))]
-        public IActionResult GenerateToken([FromQuery] string username, [FromQuery] string password, [FromQuery] string[] desiredClaims)
-        {
-            bool isValidUser = 
-                Program.validUsers.ContainsKey(username) 
-                && Program.validUsers[username].CompareTo(password) == 0;
-            if (!isValidUser)
-            {
-                return BadRequest("invalid user/pass combination");
-            }
-            var claims = desiredClaims.Select(name => new Claim($"can_{name}", true.ToString().ToLowerInvariant()));
-
-            var key = new SymmetricSecurityKey(Program.KEY);
-            var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
-            var token = new JwtSecurityToken(
-                issuer: Program.ISSUER,
-                audience: Program.AUDIENCE,
-                claims: claims,
-                expires: DateTime.Now.AddMinutes(30),
-                signingCredentials: creds
-                );
-
-            return Ok(new
-            {
-                token = new JwtSecurityTokenHandler().WriteToken(token)
-            });
         }
         [HttpGet]
         public async Task<ActionResult<List<Todo>>> GetAll()

--- a/TodoWithControllersAuthJWT/TodoController.cs
+++ b/TodoWithControllersAuthJWT/TodoController.cs
@@ -19,6 +19,7 @@ namespace Todos
         {
             _db = db ?? throw new ArgumentNullException(nameof(db));
         }
+
         [HttpGet]
         public async Task<ActionResult<List<Todo>>> GetAll()
         {

--- a/TodoWithControllersAuthJWT/TodoDbContext.cs
+++ b/TodoWithControllersAuthJWT/TodoDbContext.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+namespace Todos
+{
+    public class TodoDbContext : DbContext
+    {
+        public TodoDbContext(DbContextOptions<TodoDbContext> options) : base(options)
+        {
+
+        }
+
+        public DbSet<Todo> Todos { get; set; }
+    }
+}

--- a/TodoWithControllersAuthJWT/TodoWithControllersAuthJWT.csproj
+++ b/TodoWithControllersAuthJWT/TodoWithControllersAuthJWT.csproj
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="FeatherHttp" Version="0.1.52-alpha.g5f0ffe43df" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+</Project>

--- a/Todos.sln
+++ b/Todos.sln
@@ -1,19 +1,21 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29411.138
 MinimumVisualStudioVersion = 15.0.26124.0
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Todos", "TodoBasic\Todos.csproj", "{3F583E94-3C46-4727-A4DE-A4909D4BA094}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Todos", "TodoBasic\Todos.csproj", "{3F583E94-3C46-4727-A4DE-A4909D4BA094}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TodoWithDI", "TodoWithDI\TodoWithDI.csproj", "{85653CFF-1A49-407A-8C9D-CF32F8354D36}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TodoWithDI", "TodoWithDI\TodoWithDI.csproj", "{85653CFF-1A49-407A-8C9D-CF32F8354D36}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TodoWithScopedApi", "TodoWithScopedApi\TodoWithScopedApi.csproj", "{CC55E7E0-58BF-4458-8E42-7C4DD57BF1ED}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TodoWithScopedApi", "TodoWithScopedApi\TodoWithScopedApi.csproj", "{CC55E7E0-58BF-4458-8E42-7C4DD57BF1ED}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TodoWithNoRequestDelegate", "TodoWithNoRequestDelegate\TodoWithNoRequestDelegate.csproj", "{E59E3EC2-38E4-4268-B92F-903753FD3C84}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TodoWithNoRequestDelegate", "TodoWithNoRequestDelegate\TodoWithNoRequestDelegate.csproj", "{E59E3EC2-38E4-4268-B92F-903753FD3C84}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TodoWithControllers", "TodoWithControllers\TodoWithControllers.csproj", "{277F0126-AA7E-46D6-BDDC-B6B6729644ED}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TodoWithControllers", "TodoWithControllers\TodoWithControllers.csproj", "{277F0126-AA7E-46D6-BDDC-B6B6729644ED}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TodoWithRoutes", "TodoWithRoutes\TodoWithRoutes.csproj", "{C1261F04-4444-453D-BAF2-34A71F31A5AD}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TodoWithRoutes", "TodoWithRoutes\TodoWithRoutes.csproj", "{C1261F04-4444-453D-BAF2-34A71F31A5AD}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TodoWithControllersAuthJWT", "TodoWithControllersAuthJWT\TodoWithControllersAuthJWT.csproj", "{30ECBE4D-02A9-4566-B2FD-1D050E3F03DE}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -23,9 +25,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{3F583E94-3C46-4727-A4DE-A4909D4BA094}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -100,5 +99,23 @@ Global
 		{C1261F04-4444-453D-BAF2-34A71F31A5AD}.Release|x64.Build.0 = Release|Any CPU
 		{C1261F04-4444-453D-BAF2-34A71F31A5AD}.Release|x86.ActiveCfg = Release|Any CPU
 		{C1261F04-4444-453D-BAF2-34A71F31A5AD}.Release|x86.Build.0 = Release|Any CPU
+		{30ECBE4D-02A9-4566-B2FD-1D050E3F03DE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{30ECBE4D-02A9-4566-B2FD-1D050E3F03DE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{30ECBE4D-02A9-4566-B2FD-1D050E3F03DE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{30ECBE4D-02A9-4566-B2FD-1D050E3F03DE}.Debug|x64.Build.0 = Debug|Any CPU
+		{30ECBE4D-02A9-4566-B2FD-1D050E3F03DE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{30ECBE4D-02A9-4566-B2FD-1D050E3F03DE}.Debug|x86.Build.0 = Debug|Any CPU
+		{30ECBE4D-02A9-4566-B2FD-1D050E3F03DE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{30ECBE4D-02A9-4566-B2FD-1D050E3F03DE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{30ECBE4D-02A9-4566-B2FD-1D050E3F03DE}.Release|x64.ActiveCfg = Release|Any CPU
+		{30ECBE4D-02A9-4566-B2FD-1D050E3F03DE}.Release|x64.Build.0 = Release|Any CPU
+		{30ECBE4D-02A9-4566-B2FD-1D050E3F03DE}.Release|x86.ActiveCfg = Release|Any CPU
+		{30ECBE4D-02A9-4566-B2FD-1D050E3F03DE}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {935ECC60-B263-4513-B141-29F92C2FB080}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Supposed to fix #1 
Added JWT for local authentication and authorization.

Now, TodoWithController project is available only for users within Program.validUsers dictionary.

All methods from /api/todos (except GenerateToken) will require token validation
More than that, 
- GET /api/todos/{id} will require "user" policy, that is defined as "can_view" claim
- DELETE /api/todos/{id} will require "admin" policy, that is defined as "can_delete" claim

For demo purposes, Claims are requested on GenerateToken endpoint.
```
# pwsh
$base = "http://localhost:8888"
$payload = "username=user&password=123456&desiredClaims=delete&desiredClaims=view"
$auth = Invoke-RestMethod "$base/api/todos/GenerateToken?$payload" -Method Get
# $auth should contains token property
$info = Invoke-RestMethod "$base/api/todos/2" -Headers @{"Authorization" = "Bearer $($auth.token)"}
```

Suggestions are welcome 👋